### PR TITLE
Changed ADCS Data Packet. Added Photodiode Data as ints

### DIFF
--- a/adcs/include/comm.h
+++ b/adcs/include/comm.h
@@ -17,7 +17,7 @@
 
 // packet sizes in bytes
 #define COMMAND_LEN 4
-#define PACKET_LEN 14
+#define PACKET_LEN 26
 
 /**
  * @brief      Commands that the ADCS should expect to receive from the satellite
@@ -121,17 +121,24 @@ private:
 		struct
 		{
 			// Data can be accessed as fields - used to build packet
-			uint16_t _status;
-			fixed5_3_t _voltage;
-			int16_t _current;
-			uint8_t _speed;
-			int8_t _magX;
-			int8_t _magY;
-			int8_t _magZ;
-			fixed5_3_t _gyroX;
-			fixed5_3_t _gyroY;
-			fixed5_3_t _gyroZ;
-			uint16_t _crc;
+			uint16_t _status; //2
+			fixed5_3_t _voltage; //1
+			int16_t _current; //2
+			uint8_t _speed; //1
+			int8_t _magX; //1
+			int8_t _magY; //1
+			int8_t _magZ; //1
+			fixed5_3_t _gyroX; //1
+			fixed5_3_t _gyroY; //1
+			fixed5_3_t _gyroZ; //1
+			uint16_t _pd_xpos; //2
+			uint16_t _pd_xneg; //2
+			uint16_t _pd_ypos; //2
+			uint16_t _pd_yneg; //2
+			uint16_t _pd_zpos; //2
+			uint16_t _pd_zneg; //2 
+			uint16_t _crc; //2 
+			//Total = 26 bytes
 		};
 	};
 	
@@ -143,6 +150,7 @@ public:
 	void setINAdata(INAdata data);
 	void setSpeed(float s);
 	void setIMUdata(IMUdata data);
+	void setPDdata(PDdata_int data);
 	uint8_t *getBytes();
 	void clear();
 	void send();

--- a/adcs/include/global_definitions.h
+++ b/adcs/include/global_definitions.h
@@ -10,7 +10,7 @@
 #define GLOBAL_DEFINITIONS_H
 
 // set to 1 for the ADCS to print to the usb serial connection from SAMD51
-#define DEBUG 0
+#define DEBUG 1
 
 // create more descriptive names for serial interfaces
 #define SERCOM_USB Serial

--- a/adcs/include/sensors.h
+++ b/adcs/include/sensors.h
@@ -17,6 +17,7 @@
 
 #define NUM_IMUS 1
 #define INA 1
+#define pds 1
 
 // SENSOR VARIABLES DEFINED IN `sensors.cpp` //////////////////////////////////////
 extern INA209 ina209;
@@ -68,6 +69,21 @@ typedef union
 	};
 } PDdata;
 
+typedef union
+{
+	int data[6];
+
+	struct
+	{
+		int x_pos;
+		int x_neg;
+		int y_pos;
+		int y_neg;
+		int z_pos;
+		int z_neg;
+	};
+} PDdata_int;
+
 /* HARDWARE INIT FUNCTIONS ================================================== */
 
 void initIMU(void);
@@ -78,6 +94,8 @@ void initSunSensors(void);
 
 INAdata readINA(void);
 PDdata readPD(void);
+PDdata_int read_filtered_PD(void);
+int simple_PD_filter(int channel);
 
 /* SENSOR RTOS TASKS ======================================================== */
 

--- a/adcs/src/comm.cpp
+++ b/adcs/src/comm.cpp
@@ -138,6 +138,17 @@ void ADCSdata::setIMUdata(IMUdata data)
 	_gyroZ = floatToFixed(data.gyrZ);
 }
 
+void ADCSdata::setPDdata(PDdata_int data)
+{
+	_pd_xpos = data.x_pos;
+	_pd_xneg = data.x_neg;
+	_pd_ypos = data.y_pos;
+	_pd_yneg = data.y_neg;
+	_pd_zpos = data.z_pos;
+	_pd_zneg = data.z_neg;
+
+}
+
 /**
  * @brief      Compute CRC for validation of the packet
  */

--- a/adcs/src/rtos_tasks.cpp
+++ b/adcs/src/rtos_tasks.cpp
@@ -276,7 +276,7 @@ void heartbeat(void *pvParameters)
 	ADCSdata data_packet;
 	INAdata ina;
 	IMUdata imu;
-	PDdata pd;
+	PDdata_int pd;
 
 	uint8_t *tx_buf;
 
@@ -304,8 +304,8 @@ void heartbeat(void *pvParameters)
 				data_packet.setINAdata(ina);
 			#endif
 
-			pd = readPD();
-
+			pd = read_filtered_PD();
+			data_packet.setPDdata(pd);
 			data_packet.send(); // send to TES
 
 			#if DEBUG

--- a/adcs/src/sensors.cpp
+++ b/adcs/src/sensors.cpp
@@ -184,6 +184,61 @@ PDdata readPD(void)
 	return data;
 }
 
+
+/**
+ * @brief      filtering scheme for Photodiodes. Takes the average of the last NUM_SAMPLES readings and returns that as 1 reading.  
+ * 			   We don't need to do frequency domain analysis, so this is an acceptable smoothing filter. 
+ *
+ * @return     The analog values as integers. Planned as 12Bit reading min 0 max 4096. Data saved as 16bit int
+ */
+
+int simple_PD_filter(int channel ){
+
+	const int NUM_SAMPLES = 15; 
+	int readings[NUM_SAMPLES] = {};
+	bool first_reading = true; 
+	int flag =0; 
+	int result =0;;
+	int first = 0; 
+
+	while(first_reading)  // take n samples from the sun sensor and store them in an array 
+	{
+		for(int i = 0; i < NUM_SAMPLES; i++)
+		{
+		readings[i] =  sunSensors.read(channel);
+		first_reading = false;  
+		}
+	}
+
+	for(int i =0; i<NUM_SAMPLES; i++) // take the sum of the readings array 
+	{
+	result  += readings[i];
+	}
+	result = (int)round(float(result)/NUM_SAMPLES);
+	return result; 
+
+}
+
+/**
+ * @brief      Reading Photodiodes through simple filter scheme 
+ *
+ * @return     The analog values as integers. Planned as 12Bit reading min 0 max 4096. Data saved as 16bit int
+ */
+
+PDdata_int read_filtered_PD(void)
+{
+	PDdata_int data;
+	uint8_t channel;
+	
+	for (channel = 0; channel < 6; channel++)  // Sweep through all 6 photodiode channels. Save data to PDdata_int struct. 
+	{
+		data.data[channel] = simple_PD_filter(channel);
+	}
+	return data;
+}
+
+
+
 /* SENSOR RTOS TASKS ======================================================== */
 
 /**


### PR DESCRIPTION
Restructured ADCS packet to include photodiode data.   Each diode measurement  stored as 16bit int. New packed 26bytes long.

Added Averaging filter to PD read code.  Created new PD data type that returns as int (12 bit up to 4096)